### PR TITLE
plugins: google: update docs

### DIFF
--- a/did/plugins/google.py
+++ b/did/plugins/google.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 """
-Google stats such as attended events, completed tasks or sent emails
+Google stats such as attended events or completed tasks
 
 Config example::
 


### PR DESCRIPTION
To the best of my knowledge, as of yet, the `google` plugin does not provide stats about sent emails. Thus it should not be stated as an example of information available.